### PR TITLE
Testing/matching dtos to reversion

### DIFF
--- a/src/test/java/com/qa/choonz/rest/dto/TESTAlbumDTO.java
+++ b/src/test/java/com/qa/choonz/rest/dto/TESTAlbumDTO.java
@@ -76,24 +76,21 @@ public class TESTAlbumDTO {
 		List<Track> newTracks = new ArrayList<Track>();
 		this.testAlbumDTO.setTracks(newTracks);
 		
-		Map<Long, String> newTracksMap = new HashMap<Long, String>();
-		assertEquals(newTracksMap,this.testAlbumDTO.getTracks());
+		assertEquals(newTracks,this.testAlbumDTO.getTracks());
 	}
 	
 	@Test
 	public void getSetArtistTest() {
 		this.testAlbumDTO.setArtist(null);
 		
-		assertNull(this.testAlbumDTO.getArtistName());
-		assertNull(this.testAlbumDTO.getArtistId());
+		assertNull(this.testAlbumDTO.getArtist());
 	}
 	
 	@Test
 	public void getSetGenreTest() {
 		this.testAlbumDTO.setGenre(null);
 		
-		assertNull(this.testAlbumDTO.getGenreName());
-		assertNull(this.testAlbumDTO.getGenreName());
+		assertNull(this.testAlbumDTO.getGenre());
 	}
 	
 	@Test

--- a/src/test/java/com/qa/choonz/rest/dto/TESTArtistDTO.java
+++ b/src/test/java/com/qa/choonz/rest/dto/TESTArtistDTO.java
@@ -73,9 +73,7 @@ public class TESTArtistDTO {
 		newAlbums.add(newAlbum);
 		this.testArtist.setAlbums(newAlbums);
 		
-		Map<Long, String> newAlbumsMap = new HashMap<Long, String>();
-		newAlbumsMap.put(newAlbum.getId(), newAlbum.getName());
-		assertEquals(newAlbumsMap,this.testArtist.getAlbums());
+		assertEquals(newAlbums,this.testArtist.getAlbums());
 	}
 	
 	@Test

--- a/src/test/java/com/qa/choonz/rest/dto/TESTPlaylistDTO.java
+++ b/src/test/java/com/qa/choonz/rest/dto/TESTPlaylistDTO.java
@@ -87,10 +87,8 @@ public class TESTPlaylistDTO {
 		List<Track> newTracks = new ArrayList<Track>();
 		newTracks.add(newTrack);
 		this.testPlaylist.setTracks(newTracks);
-		Map<Long,String> track = new HashMap<Long,String>();
-		track.put(newTrack.getId(), newTrack.getName());
 		
-		assertEquals(track,this.testPlaylist.getTracks());
+		assertEquals(newTracks,this.testPlaylist.getTracks());
 	}
 	// TODO Album getting / setting not yet implemented in PlaylistDTO
 	

--- a/src/test/java/com/qa/choonz/rest/dto/TESTTrackDTO.java
+++ b/src/test/java/com/qa/choonz/rest/dto/TESTTrackDTO.java
@@ -82,8 +82,7 @@ public class TESTTrackDTO {
 		Album newAlbum = new Album();
 		this.testTrack.setAlbum(newAlbum);
 		
-		assertEquals(newAlbum.getName(), this.testTrack.getAlbumName());
-		assertEquals(newAlbum.getId(), this.testTrack.getAlbumId());
+		assertEquals(newAlbum, this.testTrack.getAlbum());
 	}
 	
 	@Test
@@ -91,8 +90,7 @@ public class TESTTrackDTO {
 		Playlist newPlaylist = new Playlist();
 		this.testTrack.setPlaylist(newPlaylist);
 		
-		assertEquals(newPlaylist.getName(),this.testTrack.getPlaylistName());
-		assertEquals(newPlaylist.getId(),this.testTrack.getPlaylistId());
+		assertEquals(newPlaylist,this.testTrack.getPlaylist());
 	}
 	
 	@Test


### PR DESCRIPTION
Fixes for all the DTO Unit tests after reverting, then updating the DTOs to use an annotation method to prevent recursion.